### PR TITLE
Fixed admiralbulldog wrong domain

### DIFF
--- a/static/bots.json
+++ b/static/bots.json
@@ -405,7 +405,7 @@
     "Hoster": "datguy1",
     "ChannelName": "admiralbulldog",
     "ChannelID": "30816637",
-    "Domain": "admiralbulldog.live"
+    "Domain": "chatbot.admiralbulldog.live"
   },
   {
     "Hoster": "datguy1",


### PR DESCRIPTION
I went to check for a command this bot specifically has and the link I tried did not load, then it dawned on me.